### PR TITLE
Updated prophet package name

### DIFF
--- a/Chapter02/Chapter_02.ipynb
+++ b/Chapter02/Chapter_02.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "from fbprophet import Prophet"
+    "from prophet import Prophet #From version 1.0 packaged changed name from fbprophet to prophet"
    ]
   },
   {


### PR DESCRIPTION
Since version 1.0 of Prophet, the old name `fbprophet` is deprecated